### PR TITLE
Improve drain XP paths

### DIFF
--- a/seed_gen/areas.xml
+++ b/seed_gen/areas.xml
@@ -3180,15 +3180,37 @@
         <Target name="DrainExp"/>
         <Requirements>
           <Requirement mode="normal">Water+Climb+ChargeJump</Requirement>
+          <Requirement mode="normal">Water+DoubleJump+Climb</Requirement>
+          <Requirement mode="normal">Water+DoubleJump+WallJump</Requirement>
+          <Requirement mode="normal">Water+DoubleJump+Glide+ChargeJump</Requirement>
+          <Requirement mode="normal">Water+ChargeFlame+Stomp+Glide+WallJump</Requirement>
+          <Requirement mode="normal">Water+Dash+Glide+Climb</Requirement>
+          <Requirement mode="extended">Water+Dash+Glide+WallJump</Requirement>
+          <Requirement mode="extended">Water+DoubleJump+ChargeJump</Requirement>
+          <Requirement mode="extreme">Water+Bash</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Climb+ChargeJump</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+Climb</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+WallJump</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+ChargeFlame+Stomp+Glide+WallJump</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+Climb</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+WallJump</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+ChargeJump</Requirement>
+        </Requirements>
+      </Connection>
+      <Connection>
+        <Home name="Swamp"/>
+        <Target name="DrainExp"/>
+        <Requirements>
+          <Requirement mode="normal">Water+Climb+ChargeJump</Requirement>
           <Requirement mode="normal">Water+DoubleJump</Requirement>
-          <Requirement mode="normal">Water+Glide</Requirement>
-          <Requirement mode="normal">Water+Dash</Requirement>
+          <Requirement mode="normal">Water+Dash+Glide+Climb</Requirement>
           <Requirement mode="normal">Water+Bash+Grenade</Requirement>
+          <Requirement mode="extended">Water+Dash+Glide+WallJump</Requirement>
           <Requirement mode="dbash">Water+Bash</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Climb+ChargeJump</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump</Requirement>
-          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Glide</Requirement>
-          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+Climb</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+WallJump</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Bash</Requirement>
         </Requirements>
       </Connection>

--- a/seed_gen/areas.xml
+++ b/seed_gen/areas.xml
@@ -3185,10 +3185,16 @@
           <Requirement mode="normal">Water+DoubleJump+Glide+ChargeJump</Requirement>
           <Requirement mode="normal">Water+ChargeFlame+Stomp+Glide+WallJump</Requirement>
           <Requirement mode="normal">Water+Grenade+Stomp+Glide+WallJump</Requirement>
+          <Requirement mode="normal">Water+Grenade+Bash+Climb</Requirement>
+          <Requirement mode="normal">Water+Grenade+Bash+WallJump</Requirement>
+          <Requirement mode="normal">Water+Grenade+Bash+Glide</Requirement>
+          <Requirement mode="normal">Water+Grenade+Bash+DoubleJump</Requirement>
           <Requirement mode="normal">Water+Dash+Glide+Climb</Requirement>
           <Requirement mode="extended">Water+Dash+Glide+WallJump</Requirement>
           <Requirement mode="extended">Water+DoubleJump+ChargeJump</Requirement>
+          <Requirement mode="dboost">HC+HC+HC+HC+Water+Grenade+Bash</Requirement>
           <Requirement mode="extreme">Water+Bash</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Bash</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Climb+ChargeJump</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+Climb</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+WallJump</Requirement>

--- a/seed_gen/areas.xml
+++ b/seed_gen/areas.xml
@@ -3199,23 +3199,6 @@
       </Connection>
       <Connection>
         <Home name="Swamp"/>
-        <Target name="DrainExp"/>
-        <Requirements>
-          <Requirement mode="normal">Water+Climb+ChargeJump</Requirement>
-          <Requirement mode="normal">Water+DoubleJump</Requirement>
-          <Requirement mode="normal">Water+Dash+Glide+Climb</Requirement>
-          <Requirement mode="normal">Water+Bash+Grenade</Requirement>
-          <Requirement mode="extended">Water+Dash+Glide+WallJump</Requirement>
-          <Requirement mode="dbash">Water+Bash</Requirement>
-          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Climb+ChargeJump</Requirement>
-          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump</Requirement>
-          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+Climb</Requirement>
-          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+WallJump</Requirement>
-          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Bash</Requirement>
-        </Requirements>
-      </Connection>
-      <Connection>
-        <Home name="Swamp"/>
         <Target name="SwampStomp"/>
         <Requirements>
           <Requirement mode="dboost-light">Stomp</Requirement>

--- a/seed_gen/areas.xml
+++ b/seed_gen/areas.xml
@@ -3184,6 +3184,7 @@
           <Requirement mode="normal">Water+DoubleJump+WallJump</Requirement>
           <Requirement mode="normal">Water+DoubleJump+Glide+ChargeJump</Requirement>
           <Requirement mode="normal">Water+ChargeFlame+Stomp+Glide+WallJump</Requirement>
+          <Requirement mode="normal">Water+Grenade+Stomp+Glide+WallJump</Requirement>
           <Requirement mode="normal">Water+Dash+Glide+Climb</Requirement>
           <Requirement mode="extended">Water+Dash+Glide+WallJump</Requirement>
           <Requirement mode="extended">Water+DoubleJump+ChargeJump</Requirement>
@@ -3192,6 +3193,7 @@
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+Climb</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+WallJump</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+ChargeFlame+Stomp+Glide+WallJump</Requirement>
+          <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Grenade+Stomp+Glide+WallJump</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+Climb</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+Dash+Glide+WallJump</Requirement>
           <Requirement mode="extreme">HC+HC+HC+HC+HC+HC+HC+DoubleJump+ChargeJump</Requirement>

--- a/seed_gen/areas.xml
+++ b/seed_gen/areas.xml
@@ -1881,7 +1881,13 @@
         <Target name="DrainExp"/>
         <Requirements>
           <Requirement mode="normal">Grenade+Climb+ChargeJump</Requirement>
+          <Requirement mode="normal">Grenade+DoubleJump+ChargeJump</Requirement>
+          <Requirement mode="normal">Grenade+Glide+ChargeJump</Requirement>
           <Requirement mode="speed">Grenade+Bash</Requirement>
+          <Requirement mode="speed">ChargeFlame+DoubleJump+Bash</Requirement>
+          <Requirement mode="speed">ChargeFlame+Glide+Bash</Requirement>
+          <Requirement mode="dboost-light">ChargeFlame+ChargeJump+DoubleJump</Requirement>
+          <Requirement mode="dboost-light">ChargeFlame+ChargeJump+Glide</Requirement>
           <Requirement mode="extended-damage">ChargeFlame+Climb+ChargeJump</Requirement>
           <Requirement mode="extended-damage">ChargeFlame+DoubleJump+WallJump</Requirement>
           <Requirement mode="extended-damage">ChargeFlame+DoubleJump+Climb</Requirement>


### PR DESCRIPTION
These changes increase the variety of paths to reach the drain XP in swamp and, in a few cases, remove impossible paths.

**Grotto to drain XP:**
- Added paths to normal to allow descending to the XP using double jump or Kuro's feather.
- Added paths to speed to allow breaking the drain with a 1-damage boost using charge flame (entering the area by breaking the ceiling with a bashed spider shot).
- Added paths to dboost-light to allow breaking the drain with a 1-damage boost using charge flame (entering the area by breaking the ceiling with charge jump).

**Swamp to drain XP:**
- Remove several impossible paths which assumed the water was already drained.
- Added several paths to navigate the area below the drain to reach the XP, whether draining the water or not (Water+DJ+C, Water+DJ+WJ, Water+DJ+KF+CJ).
- Added two paths to break the drain from below, then return above and descend to the XP (Water+CF+S+KF+WJ, Water+G+S+KF+WJ).
- Added valid bash + grenade paths (with C, WJ, KF, DJ).
- Added a normal dash path (Water+D+KF+WJ).
- Added an extended dash path (Water+D+KF+C).
- Added an extended path with a wall touch to refresh a double jump (Water+DJ+CJ).
- Added a dboost path for bash + grenade using a 3-damage boost (Water+B+G).
- Promoted a path from dbash to extreme because it involved a potentially very heinous fish dbash (Water+B).
- Added extreme variations of all the new paths, substituting 7 health (assumed Ultra Defense) for clean water. (Note: did not need to add extreme variations of the bash + grenade paths because bash-only is already in extreme.)