### PR TITLE
Added support for ability pickups

### DIFF
--- a/RandomizerItemIDs.txt
+++ b/RandomizerItemIDs.txt
@@ -55,6 +55,71 @@
 106 - Respec
 107 - Level Explosion
 
+200 - Quick Flame
+201 - Spark Flame
+202 - Charge Flame Burn
+203 - Split Flame
+204 - Ultra Light Burst
+205 - Cinder Flame
+206 - Ultra Stomp
+207 - Rapid Flame
+208 - Charge Flame Blast
+209 - Ultra Split Flame
+
+210 - Spirit Magnet
+211 - Map Markers
+212 - Life Efficiency
+213 - Ultra Spirit Magnet
+214 - Energy Efficiency
+215 - Ability Markers
+216 - Spirit Efficiency
+217 - Life Markers
+218 - Energy Markers
+219 - Sense
+
+220 - Rekindle
+221 - Regroup
+222 - Charge Flame Efficiency
+223 - Air Dash
+224 - Ultra Soul Link
+225 - Charge Dash
+226 - Water Breath
+227 - Soul Link Efficiency
+228 - Triple Jump
+229 - Ultra Defense
+
+230 - Lose Quick Flame
+231 - Lose Spark Flame
+232 - Lose Charge Flame Burn
+233 - Lose Split Flame
+234 - Lose Ultra Light Burst
+235 - Lose Cinder Flame
+236 - Lose Ultra Stomp
+237 - Lose Rapid Flame
+238 - Lose Charge Flame Blast
+239 - Lose Ultra Split Flame
+
+240 - Lose Spirit Magnet
+241 - Lose Map Markers
+242 - Lose Life Efficiency
+243 - Lose Ultra Spirit Magnet
+244 - Lose Energy Efficiency
+245 - Lose Ability Markers
+246 - Lose Spirit Efficiency
+247 - Lose Life Markers
+248 - Lose Energy Markers
+249 - Lose Sense
+
+250 - Lose Rekindle
+251 - Lose Regroup
+252 - Lose Charge Flame Efficiency
+253 - Lose Air Dash
+254 - Lose Ultra Soul Link
+255 - Lose Charge Dash
+256 - Lose Water Breath
+257 - Lose Soul Link Efficiency
+258 - Lose Triple Jump
+259 - Lose Ultra Defense
 
 1000 - plant tracking for map markers
 1001 - tree field for tracker

--- a/randomizer/RandomizerBonus.cs
+++ b/randomizer/RandomizerBonus.cs
@@ -14,11 +14,27 @@ public static class RandomizerBonus
         {
             ID = -ID;
         }
-        if (ID >= 100)
+        
+        if (ID >= 100 && ID < 200)
         {
             RandomizerBonusSkill.FoundBonusSkill(ID);
             return;
         }
+        if (ID >= 200 && ID < 260)
+        {
+            var abilityIndex = (ID - 200) % 30;
+            var ability = abilities[abilityIndex];
+            if (ID < 230)
+            {
+                ability.Found();
+            }
+            else
+            {
+                ability.Lost();
+            }
+            return;
+        }
+        
         switch (ID)
         {
         case 0:
@@ -278,7 +294,6 @@ public static class RandomizerBonus
                 Randomizer.showHint("Energy Drain");
             else
                 Randomizer.showHint("Health Drain x" + RandomizerBonus.Manavamp().ToString());
-            break;
             break;
         case 33:
             if (!flag)
@@ -595,4 +610,69 @@ public static class RandomizerBonus
 
     // Token: 0x04003262 RID: 12898
     public static bool DoubleAirDashUsed;
+    
+    private class Ability
+    {
+        public Ability(string name, Func<PlayerAbilities, CharacterAbility> selector)
+        {
+            this.name = name;
+            this.selector = selector;
+        }
+        
+        public void Found()
+        {
+            if (!Characters.Sein)
+                return;
+            Randomizer.showHint("$" + name + "$", 240);
+            selector(Characters.Sein.PlayerAbilities).HasAbility = true;
+        }
+        
+        public void Lost()
+        {
+            if (!Characters.Sein)
+                return;
+            Randomizer.showHint("@" + name + " Lost!!@", 240);
+            selector(Characters.Sein.PlayerAbilities).HasAbility = false;
+        }
+        
+        private string name;
+        
+        private Func<PlayerAbilities, CharacterAbility> selector;
+    }
+    
+    private static Ability[] abilities = new Ability[]
+    {
+        new Ability("Quick Flame", p => p.QuickFlame),
+        new Ability("Spark Flame", p => p.SparkFlame),
+        new Ability("Charge Flame Burn", p => p.ChargeFlameBurn),
+        new Ability("Split Flame", p => p.SplitFlameUpgrade),
+        new Ability("Ultra Light Burst", p => p.GrenadeUpgrade),
+        new Ability("Cinder Flame", p => p.CinderFlame),
+        new Ability("Ultra Stomp", p => p.StompUpgrade),
+        new Ability("Rapid Flame", p => p.RapidFire),
+        new Ability("Charge Flame Blast", p => p.ChargeFlameBlast),
+        new Ability("Ultra Split Flame", p => p.UltraSplitFlame),
+
+        new Ability("Spirit Magnet", p => p.Magnet),
+        new Ability("Map Markers", p => p.MapMarkers),
+        new Ability("Life Efficiency", p => p.HealthEfficiency),
+        new Ability("Ultra Spirit Magnet", p => p.UltraMagnet),
+        new Ability("Energy Efficiency", p => p.EnergyEfficiency),
+        new Ability("Ability Markers", p => p.AbilityMarkers),
+        new Ability("Spirit Efficiency", p => p.SoulEfficiency),
+        new Ability("Life Markers", p => p.HealthMarkers),
+        new Ability("Energy Markers", p => p.EnergyMarkers),
+        new Ability("Sense", p => p.Sense),
+
+        new Ability("Rekindle", p => p.Rekindle),
+        new Ability("Regroup", p => p.Regroup),
+        new Ability("Charge Flame Efficiency", p => p.ChargeFlameEfficiency),
+        new Ability("Air Dash", p => p.AirDash),
+        new Ability("Ultra Soul Link", p => p.UltraSoulFlame),
+        new Ability("Charge Dash", p => p.ChargeDash),
+        new Ability("Water Breath", p => p.WaterBreath),
+        new Ability("Soul Link Efficiency", p => p.SoulFlameEfficiency),
+        new Ability("Triple Jump", p => p.DoubleJumpUpgrade),
+        new Ability("Ultra Defense", p => p.UltraDefense)
+    };
 }


### PR DESCRIPTION
Ability pickups use ids RB|200 through RB|229.
The order is red tree, purple tree, blue tree in the oder as seen in the game.
RB|230 through RB|259 remove abilities, in the same order.